### PR TITLE
Update clear feature to support confirmation message

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -47,4 +47,9 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Set pending status of clear function
+     */
+    public void setClearPendingStatus(boolean isPending);
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -32,6 +32,7 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
+    private boolean pendingClear;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -40,11 +41,17 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
+
     }
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        if (pendingClear) {
+            addressBookParser.setClearPendingStatus(true);
+            this.pendingClear = false;
+        }
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
@@ -59,6 +66,10 @@ public class LogicManager implements Logic {
         }
 
         return commandResult;
+    }
+
+    public void setClearPendingStatus(boolean isPending) {
+        this.pendingClear = isPending;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ActualClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ActualClearCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+
+/**
+ * Actually clears the address book
+ */
+public class ActualClearCommand extends Command {
+
+    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setAddressBook(new AddressBook());
+        return new CommandResult(MESSAGE_SUCCESS);
+
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -2,22 +2,22 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Confirms whether user wants to clear the address book.
  */
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
-
+    public static final String MESSAGE_FAILURE = "Address book has not been cleared!";
+    public static final String MESSAGE_CONFIRMATION = "Are you sure you want to clear all your contacts? This is an "
+            + "irreversible action. (Y/Yes or N/No)";
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.setAddressBook(new AddressBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_CONFIRMATION, false, false, true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -12,8 +12,8 @@ public class ClearCommand extends Command {
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
     public static final String MESSAGE_FAILURE = "Address book has not been cleared!";
-    public static final String MESSAGE_CONFIRMATION = "Are you sure you want to clear all your contacts? This is an "
-            + "irreversible action. (Y/Yes or N/No)";
+    public static final String MESSAGE_CONFIRMATION = "Are you sure you want to permanently clear all your contacts? "
+            + "\nType 'Y'/'Yes' to confirm, or any other input to cancel";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.ClearCommand.MESSAGE_CONFIRMATION;
 
 import java.util.Objects;
 
@@ -19,13 +20,17 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The clear command confirmation is pending */
+    private boolean pendingClear;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean pendingClear) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.pendingClear = pendingClear;
     }
 
     /**
@@ -33,7 +38,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, feedbackToUser.contains(MESSAGE_CONFIRMATION));
     }
 
     public String getFeedbackToUser() {
@@ -46,6 +51,10 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isPendingClear() {
+        return pendingClear;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ActualClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ActualClearCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ActualClearCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Handles parsing for user confirmation to clear all contacts
+ */
+public class ActualClearCommandParser implements Parser<ActualClearCommand> {
+    public static final String MESSAGE_FAILURE = "Address book has not been cleared!";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ActualClearCommand
+     * and returns a ActualClearCommand object for execution.
+     * @return ActualClearCommand
+     * @throws ParseException ParseException if the user input is not 'yes' or 'y'
+     */
+    public ActualClearCommand parse(String args) throws ParseException {
+        String input = args.toLowerCase().trim();
+
+        if (input.equals("yes") || input.equals("y")) {
+            return new ActualClearCommand();
+        }
+
+        throw new ParseException(MESSAGE_FAILURE);
+
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -30,6 +30,7 @@ public class AddressBookParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
+    private boolean pendingClear;
 
     /**
      * Parses user input into command for execution.
@@ -39,6 +40,11 @@ public class AddressBookParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public Command parseCommand(String userInput) throws ParseException {
+        if (pendingClear) {
+            pendingClear = false;
+            return new ActualClearCommandParser().parse(userInput);
+        }
+
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -87,4 +93,7 @@ public class AddressBookParser {
         }
     }
 
+    public void setClearPendingStatus(boolean pendingStatus) {
+        this.pendingClear = pendingStatus;
+    }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -35,6 +35,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
+
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -169,15 +170,18 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Executes the command and returns the result.
-     *
      * @see seedu.address.logic.Logic#execute(String)
      */
     private CommandResult executeCommand(String commandText) throws CommandException, ParseException {
         try {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
+
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
+            if (commandResult.isPendingClear()) {
+                logic.setClearPendingStatus(true);
+            }
             if (commandResult.isShowHelp()) {
                 handleHelp();
             }

--- a/src/test/java/seedu/address/logic/commands/ActualClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ActualClearCommandTest.java
@@ -10,14 +10,14 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
-public class ClearCommandTest {
+public class ActualClearCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ActualClearCommand(), model, ActualClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class ClearCommandTest {
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel.setAddressBook(new AddressBook());
 
-        assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ActualClearCommand(), model, ActualClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
     }
 
     @Test
@@ -46,10 +46,10 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Closes #56 

When the "clear" command is run, a confirmation message is shown to direct the user to confirm whether they actually want to delete all contacts in the addressbook. This helps circumvent the accidental wiping of data, especially if 'clear' is mistaken for 'delete' by the user.