### PR TITLE
Bug fixes for Tag Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -60,6 +60,10 @@ public class TagCommand extends Command {
         Person newPerson = new Person(personToTag.getName(), personToTag.getPhone(),
                 personToTag.getEmail(), personToTag.getAddress(), addedTags);
 
+        if (newPerson.getTags().size() > 6) {
+            throw new CommandException("Each person can only have up to 6 tags!");
+        }
+
         // Updating addressBook
         model.setPerson(personToTag, newPerson);
         model.getActiveTags().incrementTags(addedTags);

--- a/src/main/java/seedu/address/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TagCommandParser.java
@@ -36,7 +36,13 @@ public class TagCommandParser implements Parser<TagCommand> {
 
         Index index = ParserUtil.parseIndex(multimap.getPreamble());
         String tags = multimap.getValue(PREFIX_TAG).orElse("");
-        Set<Tag> tagSet = Tag.stringToTagSet(tags);
+
+        Set<Tag> tagSet;
+        try {
+            tagSet = Tag.stringToTagSet(tags);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, e.getMessage()));
+        }
 
         // If t/ prefix is followed by empty string
         if (tagSet.isEmpty()) {

--- a/src/main/java/seedu/address/model/tag/ActiveTags.java
+++ b/src/main/java/seedu/address/model/tag/ActiveTags.java
@@ -27,8 +27,6 @@ public class ActiveTags {
                 tagMap.put(t, 1);
             }
         }
-
-        System.out.println(this.getMap().toString());
     }
 
     /**
@@ -45,8 +43,6 @@ public class ActiveTags {
                 tagMap.replace(t, --i);
             }
         }
-
-        System.out.println(this.getMap().toString());
     }
 
     public HashMap<Tag, Integer> getMap() {

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
-import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -66,5 +67,15 @@ public class TagCommandTest {
         TagCommand tagCommand = new TagCommand(outOfBoundsIndex, tagList);
 
         assertCommandFailure(tagCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_excessiveTagsFilteredList_failure() {
+        Index index = INDEX_FIRST_PERSON;
+
+        Set<Tag> tagSet = SampleDataUtil.getTagSet("tag1", "tag2", "tag3", "tag4", "tag5", "tag6");
+        TagCommand command = new TagCommand(index, tagSet);
+        String expectedMessage = "Each person can only have up to 6 tags!";
+        assertCommandFailure(command, model, expectedMessage);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/TagCommandParserTest.java
@@ -59,4 +59,14 @@ public class TagCommandParserTest {
 
         assertParseFailure(parser, userInput, expectedMessage);
     }
+
+    @Test
+    public void parse_nonAlphanumericArgs_failure() {
+        TagCommandParser parser = new TagCommandParser();
+        String userInput = INDEX_FIRST_PERSON.getOneBased() + " t/bad*arg__!";
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                "Tags names should be alphanumeric");
+
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
 }


### PR DESCRIPTION
1. TagCommandParser now catches non alphanumeric inputs
2. TagCommand now enforces max 6 tags per person
3. Removed irrelevant print statements related to testing