### PR TITLE
Improve FilterCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,9 +1,12 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.function.Predicate;
+import java.util.Set;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -17,31 +20,55 @@ public class FilterCommand extends Command {
     public static final String COMMAND_WORD = "filter";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": filters contacts by tags. \n"
-            + "Parameters: t/ [TAG]\n"
-            + "Example: " + COMMAND_WORD + "t/ friends";
+            + ": filters contacts by one or more tags. \n"
+            + "Parameters: " + PREFIX_TAG + "TAG1 [TAG2] [TAG3] ..\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "friends colleagues";
 
     public static final String MESSAGE_SUCCESS =
-            "Listed all contacts with tag: %1$s \n"
+            "Listed all contacts with tags: %1$s \n"
             + "Type \"list\" to see all contacts.";
+
+    public static final String MESSAGE_DUPLICATE_PREFIXES = "Please only include one prefix t/ !";
 
     public final Predicate<Person> predicatePersonTaggedWithTag;
 
-    private final Tag tag;
+    private final Set<Tag> tagSet;
 
     /**
      * Creates a FilterCommand object with the specified tag.
-     * @param tag
+     * @param tagSet
      */
-    public FilterCommand(Tag tag) {
-        this.tag = tag;
-        this.predicatePersonTaggedWithTag = new PersonTaggedWithPredicate(this.tag);
+    public FilterCommand(Set<Tag> tagSet) {
+        this.tagSet = tagSet;
+        this.predicatePersonTaggedWithTag = new PersonTaggedWithPredicate(this.tagSet);
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(predicatePersonTaggedWithTag);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, tag));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, tagSet));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FilterCommand)) {
+            return false;
+        }
+
+        FilterCommand otherFilterCommand = (FilterCommand) other;
+        return tagSet.equals(otherFilterCommand.tagSet);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("tagSet", tagSet)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -3,8 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.function.Predicate;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.Set;
+
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
@@ -21,7 +23,14 @@ public class FilterCommandParser implements Parser<FilterCommand> {
     public FilterCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
-        argumentMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TAG);
+
+        // Catching duplicate prefixes
+        try {
+            argumentMultimap.verifyNoDuplicatePrefixesFor(PREFIX_TAG);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    FilterCommand.MESSAGE_DUPLICATE_PREFIXES));
+        }
 
         String tagString = argumentMultimap.getValue(PREFIX_TAG).orElse("");
         if (tagString.equals("")) {
@@ -29,8 +38,8 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         }
 
         try {
-            Tag tag = new Tag(tagString);
-            return new FilterCommand(tag);
+            Set<Tag> tagSet = Tag.stringToTagSet(tagString);
+            return new FilterCommand(tagSet);
         } catch (IllegalArgumentException e) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/person/PersonTaggedWithPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonTaggedWithPredicate.java
@@ -1,7 +1,7 @@
 package seedu.address.model.person;
 
-import java.util.function.Predicate;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/model/person/PersonTaggedWithPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonTaggedWithPredicate.java
@@ -1,21 +1,22 @@
 package seedu.address.model.person;
 
 import java.util.function.Predicate;
+import java.util.Set;
 
 import seedu.address.model.tag.Tag;
 
 /**
- * Tests that a {@code Person} is tagged with {@code Tag}
+ * Tests that a {@code Person} is tagged with all tags in {@code Set<Tag>}
  */
 public class PersonTaggedWithPredicate implements Predicate<Person> {
-    private final Tag tag;
+    private final Set<Tag> tagSet;
 
-    public PersonTaggedWithPredicate(Tag tag) {
-        this.tag = tag;
+    public PersonTaggedWithPredicate(Set<Tag> tagSet) {
+        this.tagSet = tagSet;
     }
 
     @Override
     public boolean test(Person person) {
-        return person.getTags().stream().anyMatch(t -> t.equals(tag));
+        return person.getTags().containsAll(tagSet);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -19,6 +20,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 
 /**
@@ -36,6 +38,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_TAG_FRIENDS = "friends";
+    public static final String VALID_TAG_OWESMONEY = "owesMoney";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -47,6 +51,16 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_FRIEND_HUSBAND = " " + PREFIX_TAG + VALID_TAG_FRIEND + " " + VALID_TAG_HUSBAND;
+    public static final String TAG_DESC_FRIENDS= " " + PREFIX_TAG + VALID_TAG_FRIENDS;
+    public static final String TAG_DESC_FRIENDS_OWESMONEY = " " + PREFIX_TAG + VALID_TAG_FRIENDS
+            + " " + VALID_TAG_OWESMONEY;
+    public static final Set<Tag> TAG_SET_FRIEND = Set.of(new Tag(VALID_TAG_FRIEND));
+    public static final Set<Tag> TAG_SET_FRIEND_HUSBAND = Set.of(new Tag(VALID_TAG_FRIEND), new Tag(VALID_TAG_HUSBAND));
+    public static final Set<Tag> TAG_SET_FRIENDS = Set.of(new Tag(VALID_TAG_FRIENDS));
+    public static final Set<Tag> TAG_SET_OWESMONEY = Set.of(new Tag(VALID_TAG_OWESMONEY));
+    public static final Set<Tag> TAG_SET_FRIENDS_OWESMONEY = Set.of(new Tag(VALID_TAG_FRIENDS),
+            new Tag(VALID_TAG_OWESMONEY));
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,13 +52,9 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String TAG_DESC_FRIEND_HUSBAND = " " + PREFIX_TAG + VALID_TAG_FRIEND + " " + VALID_TAG_HUSBAND;
-    public static final String TAG_DESC_FRIENDS= " " + PREFIX_TAG + VALID_TAG_FRIENDS;
-    public static final String TAG_DESC_FRIENDS_OWESMONEY = " " + PREFIX_TAG + VALID_TAG_FRIENDS
-            + " " + VALID_TAG_OWESMONEY;
     public static final Set<Tag> TAG_SET_FRIEND = Set.of(new Tag(VALID_TAG_FRIEND));
     public static final Set<Tag> TAG_SET_FRIEND_HUSBAND = Set.of(new Tag(VALID_TAG_FRIEND), new Tag(VALID_TAG_HUSBAND));
     public static final Set<Tag> TAG_SET_FRIENDS = Set.of(new Tag(VALID_TAG_FRIENDS));
-    public static final Set<Tag> TAG_SET_OWESMONEY = Set.of(new Tag(VALID_TAG_OWESMONEY));
     public static final Set<Tag> TAG_SET_FRIENDS_OWESMONEY = Set.of(new Tag(VALID_TAG_FRIENDS),
             new Tag(VALID_TAG_OWESMONEY));
 

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,0 +1,80 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIENDS;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIENDS_OWESMONEY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.PersonTaggedWithPredicate;
+
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code FilterCommand}.
+ */
+public class FilterCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_oneValidTag_success() {
+        FilterCommand command = new FilterCommand(TAG_SET_FRIENDS);
+
+        String expectedMessage = String.format(FilterCommand.MESSAGE_SUCCESS, TAG_SET_FRIENDS);
+        PersonTaggedWithPredicate predicate = new PersonTaggedWithPredicate(TAG_SET_FRIENDS);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_twoValidTags_success() {
+        FilterCommand command = new FilterCommand(TAG_SET_FRIENDS_OWESMONEY);
+
+        String expectedMessage = String.format(FilterCommand.MESSAGE_SUCCESS, TAG_SET_FRIENDS_OWESMONEY);
+        PersonTaggedWithPredicate predicate = new PersonTaggedWithPredicate(TAG_SET_FRIENDS_OWESMONEY);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void equals() {
+        FilterCommand filterTagFriends = new FilterCommand(TAG_SET_FRIENDS);
+        FilterCommand filterTagFriendsOwesMoney = new FilterCommand(TAG_SET_FRIENDS_OWESMONEY);
+
+        // same object -> returns true
+        assertTrue(filterTagFriends.equals(filterTagFriends));
+
+        // same values -> returns true
+        FilterCommand filterTagFriendCopy = new FilterCommand(TAG_SET_FRIENDS);
+        assertTrue(filterTagFriends.equals(filterTagFriendCopy));
+
+        // different types -> returns false
+        assertFalse(filterTagFriends.equals(1));
+
+        // null -> returns false
+        assertFalse(filterTagFriends.equals(null));
+
+        // different set of tags -> returns false
+        assertFalse(filterTagFriends.equals(filterTagFriendsOwesMoney));
+    }
+
+    @Test
+    public void toStringMethod() {
+        Index targetIndex = Index.fromOneBased(1);
+        FilterCommand filterCommand = new FilterCommand(TAG_SET_FRIEND);
+        String expected = FilterCommand.class.getCanonicalName() + "{tagSet=" + TAG_SET_FRIEND + "}";
+        assertEquals(expected, filterCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIEND_HUSBAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -20,6 +22,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -99,6 +102,12 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        FilterCommand command = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD + TAG_DESC_FRIEND_HUSBAND);
+        assertEquals(new FilterCommand(TAG_SET_FRIEND_HUSBAND), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -106,7 +106,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_filter() throws Exception {
-        FilterCommand command = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD + TAG_DESC_FRIEND_HUSBAND);
+        FilterCommand command = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD
+                + TAG_DESC_FRIEND_HUSBAND);
         assertEquals(new FilterCommand(TAG_SET_FRIEND_HUSBAND), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -20,7 +20,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.model.tag.Tag;
 
 public class FilterCommandParserTest {
-    FilterCommandParser parser = new FilterCommandParser();
+    private FilterCommandParser parser = new FilterCommandParser();
 
     @Test
     public void parse_oneTag_success() {

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIEND_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.tag.Tag;
+
+public class FilterCommandParserTest {
+    FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_oneTag_success() {
+        Set<Tag> tagSet = TAG_SET_FRIEND;
+        FilterCommand expectedCommand = new FilterCommand(tagSet);
+        assertParseSuccess(parser, TAG_DESC_FRIEND, expectedCommand);
+    }
+
+    @Test
+    public void parse_twoTags_success() {
+        String userInput = TAG_DESC_FRIEND_HUSBAND;
+        Set<Tag> tagSet = TAG_SET_FRIEND_HUSBAND;
+        FilterCommand expectedCommand = new FilterCommand(tagSet);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        String userInput = PREFIX_TAG + "     ";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_missingPrefix_throwsParseException() {
+        String userInput = "friend";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_duplicatePrefixes_throwsParseException() {
+        String userInput = PREFIX_TAG + TAG_DESC_FRIEND + " " + PREFIX_TAG + TAG_DESC_HUSBAND;
+        String expectedMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                FilterCommand.MESSAGE_DUPLICATE_PREFIXES);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    public void parse_nonAlphanumericTag_throwsParseException() {
+        String userInput = INVALID_TAG_DESC;
+        String expectedMessage = Tag.MESSAGE_CONSTRAINTS;
+
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+}

--- a/src/test/java/seedu/address/model/person/PersonTaggedWithPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTaggedWithPredicateTest.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIENDS;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_SET_FRIENDS_OWESMONEY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIENDS;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_OWESMONEY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class PersonTaggedWithPredicateTest {
+    @Test
+    public void test_personTaggedWith_returnsTrue() {
+        // One tag
+        PersonTaggedWithPredicate predicateOneTag = new PersonTaggedWithPredicate(TAG_SET_FRIENDS);
+        assertTrue(predicateOneTag.test(new PersonBuilder().withTags(VALID_TAG_FRIENDS).build()));
+
+        // Multiple tags
+        PersonTaggedWithPredicate predicateTwoTags = new PersonTaggedWithPredicate(TAG_SET_FRIENDS_OWESMONEY);
+        assertTrue(predicateTwoTags.test(new PersonBuilder().withTags(VALID_TAG_FRIENDS, VALID_TAG_OWESMONEY).build()));
+    }
+
+    @Test
+    public void test_personTaggedWith_returnsFalse() {
+        // Person has zero tags
+        PersonTaggedWithPredicate predicatePersonNoTags = new PersonTaggedWithPredicate(TAG_SET_FRIENDS);
+        assertFalse(predicatePersonNoTags.test(new PersonBuilder().build()));
+
+        // Non-matching tag
+        PersonTaggedWithPredicate predicateDifferentTag = new PersonTaggedWithPredicate(TAG_SET_FRIENDS);
+        assertFalse(predicateDifferentTag.test(new PersonBuilder().withTags(VALID_TAG_OWESMONEY).build()));
+    }
+}


### PR DESCRIPTION
- Edited FilterCommand to take in multiple tags separated by spaces
- Added functionality for filtering by multiple tags
- Added tests for FilterCommand, FilterCommanParser, AddressBookParser and PersonTaggedWithPredicate
- Added a few utility Set<Tag> and descriptions to CommandTestUtil

Addresses #84, #79, #81 