### PR TITLE
Fix wedding update bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonId;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
@@ -93,6 +94,7 @@ public class EditCommand extends Command {
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
 
+        PersonId unchangedId = personToEdit.getId();
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
@@ -101,9 +103,9 @@ public class EditCommand extends Command {
         assert updatedPhone != null : "Updated phone should not be null";
         assert updatedEmail != null : "Updated email should not be null";
         assert updatedAddress != null : "Updated address should not be null";
-        Set<Tag> updatedTags = personToEdit.getTags();
+        Set<Tag> unchangedTags = personToEdit.getTags();
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(unchangedId, updatedName, updatedPhone, updatedEmail, updatedAddress, unchangedTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -62,7 +62,7 @@ public class TagCommand extends Command {
         addedTags.addAll(personToTag.getTags());
 
         // Creating new Person
-        Person newPerson = new Person(personToTag.getName(), personToTag.getPhone(),
+        Person newPerson = new Person(personToTag.getId(), personToTag.getName(), personToTag.getPhone(),
                 personToTag.getEmail(), personToTag.getAddress(), addedTags);
 
         if (newPerson.getTags().size() > 6) {

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -67,7 +67,7 @@ public class UntagCommand extends Command {
             tagsToRemoveFromPerson = this.tagsToRemove;
         }
 
-        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), this.removeTags(personToEdit.getTags(), tagsToRemoveFromPerson));
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -67,8 +67,9 @@ public class UntagCommand extends Command {
             tagsToRemoveFromPerson = this.tagsToRemove;
         }
 
-        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), this.removeTags(personToEdit.getTags(), tagsToRemoveFromPerson));
+        Person editedPerson = new Person(personToEdit.getId(), personToEdit.getName(),
+                personToEdit.getPhone(), personToEdit.getEmail(), personToEdit.getAddress(),
+                this.removeTags(personToEdit.getTags(), tagsToRemoveFromPerson));
 
         model.setPerson(personToEdit, editedPerson);
         model.getActiveTags().decrementTag(tagsToRemoveFromPerson);


### PR DESCRIPTION
Update Edit, Tag, and Untag commands to retain existing UUIDs when modifying a person's details/tags using overloaded Person constructor. This prevents the contact from appearing to be deleted from a wedding because a new UUID was being generated

Closes #153 