### PR TITLE
Increase result panel height

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignContactToWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignContactToWeddingCommand.java
@@ -26,7 +26,7 @@ public class AssignContactToWeddingCommand extends Command {
     public static final String COMMAND_WORD = "assign";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns contacts to a specific wedding "
-            + "where the wedding and contacts are identified by their index number. \n"
+            + "where the wedding & contacts are identified by their index number. \n"
             + "Parameters: assign WeddingIndex (must be a positive integer) "
             + PREFIX_CONTACT + "(specify at least 1 person index to assign)... \n"
             + "Example: " + COMMAND_WORD + " 1 "

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -32,9 +32,8 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the personal details of the "
-            + "contact in the specified index. Existing values will be overwritten by input values "
-            + "only in fields for which a new value is provided.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the provided personal details of the "
+            + "contact in the specified index.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,7 +16,7 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (case-insensitive)\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 

--- a/src/main/java/seedu/address/logic/commands/UnassignContactFromWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignContactFromWeddingCommand.java
@@ -25,7 +25,7 @@ public class UnassignContactFromWeddingCommand extends Command {
     public static final String COMMAND_WORD = "unassign";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unassigns contacts from a specific wedding "
-            + "where the wedding and contacts are identified by their index number. \n"
+            + "where the wedding & contacts are identified by their index number.\n"
             + "Parameters: unassign WeddingIndex (must be a positive integer) "
             + PREFIX_CONTACT + "(specify at least 1 person index to assign)... \n"
             + "Example: " + COMMAND_WORD + " 1 "

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -150,8 +150,11 @@
 .result-display {
     -fx-background-color: transparent;
     -fx-font-family: "Segoe UI Light";
-    -fx-font-size: 13pt;
+    -fx-font-size: 11.5pt;
     -fx-text-fill: white;
+    -fx-min-height: 110;
+    -fx-pref-height: 110;
+    -fx-max-height: 110;
 }
 
 .result-display .label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -36,7 +36,7 @@
         </StackPane>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
+                   minHeight="150" prefHeight="150" maxHeight="150">
           <padding>
             <Insets top="5" right="10" bottom="5" left="10" />
           </padding>


### PR DESCRIPTION
Increased results panel height
Update command usage messages to be more concise so that the user would never have to scroll in the results pane

<img width="844" alt="Screenshot 2024-10-28 at 1 10 32 PM" src="https://github.com/user-attachments/assets/24be5868-e68f-4d5a-a5b2-501caf954ddc">

Closes #181 
