### PR TITLE
Debug edit wedding and update minor UI issues

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditWeddingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditWeddingCommand.java
@@ -27,9 +27,10 @@ public class EditWeddingCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits wedding \n"
-            + "Parameters: INDEX (must be a positive integer) " + PREFIX_NAME + "NAME "
-            + PREFIX_DATE + "DATE\n"
-            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NAME + "Pb&J " + PREFIX_DATE + "21/03/2024";
+            + "Parameters: INDEX (must be a positive integer) " + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_DATE + "DATE]\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NAME + "PB and J Wedding " + PREFIX_DATE
+            + "21/03/2024";
 
     public static final String MESSAGE_SUCCESS = "Edited Wedding: %1$s \n";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -77,6 +78,12 @@ public class EditWeddingCommand extends Command {
         }
 
         model.setWedding(weddingToEdit, editedWedding);
+
+        // check if wedding currently viewed is the wedding being edited, if it is set current wedding name
+        // to be the same as the edited wedding's name
+        if (weddingToEdit.getWeddingName().equals(model.getCurrentWeddingName().getValue())) {
+            model.setCurrentWeddingName(editedWedding.getWeddingName());
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatWedding(editedWedding)));
 
 
@@ -91,7 +98,7 @@ public class EditWeddingCommand extends Command {
         assert updatedWeddingName != null : "Updated name should not be null";
         assert updatedWeddingDate != null : "Updated phone should not be null";
 
-        return new Wedding(updatedWeddingName, updatedWeddingDate);
+        return new Wedding(updatedWeddingName, updatedWeddingDate, weddingToEdit.getAssignees());
     }
 
     @Override

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -353,6 +353,7 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+    -fx-font-weight: bold;
 }
 
 .pane-with-border {


### PR DESCRIPTION
Resolves #192, #193, #215, #216

Fixed the following issues for EditWeddingCommand:
1. No longer clears all the contacts of the edited wedding
2. If currently viewing wedding which is edited, the name display will automatically refresh to show the new edited name
3. Now the example usage name field no longer contains an invalid character "&" 
4. Added brackets to denote n/NAME and d/DATE as being optional

Also made tag labels bold to improve readability