### PR TITLE
Prevent Tags from being named 'all'

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -41,7 +41,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             Set<Tag> tagSet = Tag.stringToTagSet(tagString);
             return new FilterCommand(tagSet);
         } catch (IllegalArgumentException e) {
-            throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+            throw new ParseException(e.getMessage());
         }
     }
 }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -3,11 +3,9 @@ package seedu.address.model.tag;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Represents a Tag in the address book.
@@ -17,6 +15,7 @@ public class Tag {
     public static final int TAG_MAX_LEN = 16;
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
     public static final String MESSAGE_CHAR_LIMIT = "Tag names cannot exceed " + TAG_MAX_LEN + " characters!";
+    public static final String MESSAGE_TAG_NAMED_ALL = "Tags cannot be named 'all' as it is a special keyword!";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -26,10 +25,15 @@ public class Tag {
      *
      * @param tagName A valid tag name.
      */
-    public Tag(String tagName) {
+    public Tag(String tagName) throws IllegalArgumentException {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         checkArgument(isWithinCharLimit(tagName), MESSAGE_CHAR_LIMIT);
+
+        if (tagName.equalsIgnoreCase("all")) {
+            throw new IllegalArgumentException(MESSAGE_TAG_NAMED_ALL);
+        }
+
         this.tagName = tagName;
     }
 
@@ -98,14 +102,18 @@ public class Tag {
      * @param tagString Input string to parse
      * @return
      */
-    public static Set<Tag> stringToTagSet(String tagString) {
+    public static Set<Tag> stringToTagSet(String tagString) throws IllegalArgumentException {
         String[] strArr = tagString.split("\\s+"); // regex to catch multiple spaces
         // Catch edge case if strArr is length 1 with element ""
         if (strArr.length == 0 || strArr[0].equals("")) {
             return new HashSet<>();
         } else {
-            Set<Tag> tagSet = Arrays.stream(strArr).map(Tag::new).collect(Collectors.toSet());
-            return tagSet;
+            Set<Tag> result = new HashSet<>();
+            for (String s:strArr) {
+                Tag newTag = new Tag(s);
+                result.add(newTag);
+            }
+            return result;
         }
     }
 

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -23,6 +23,12 @@ public class TagTest {
     }
 
     @Test
+    public void constructor_tagNamedAll_throwsIllegalArgumentException() {
+        String invalidTagName = "all";
+        assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    }
+
+    @Test
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));


### PR DESCRIPTION
Resolve #309

Added check to prevent tags from being named 'all', case insensitive.