### PR TITLE
Fix storage errors

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_TAG_LIST_SIZE = "A contact can only have up to 6 tags \n";
+    public static final String MESSAGE_INVALID_TAG_LIST_SIZE = "A contact can only have up to 6 tags";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX =
             "1 or more contact indexes provided is invalid";
 

--- a/src/main/java/seedu/address/logic/commands/TagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TagCommand.java
@@ -62,18 +62,18 @@ public class TagCommand extends Command {
         // Union of existing tags and new tags
         addedTags.addAll(personToTag.getTags());
 
-        // Creating new Person
-        Person newPerson = new Person(personToTag.getId(), personToTag.getName(), personToTag.getPhone(),
-                personToTag.getEmail(), personToTag.getAddress(), addedTags);
+        try {
+            // Creating new Person
+            Person newPerson = new Person(personToTag.getId(), personToTag.getName(), personToTag.getPhone(),
+                    personToTag.getEmail(), personToTag.getAddress(), addedTags);
 
-        if (newPerson.getTags().size() > 6) {
-            throw new CommandException("Each person can only have up to 6 tags!");
+            // Updating addressBook
+            model.setPerson(personToTag, newPerson);
+            model.getActiveTags().incrementTags(addedTags);
+            return new CommandResult(String.format(MESSAGE_TAG_PERSON_SUCCESS, personToTag.getName(), addedTagsString));
+        } catch (IllegalArgumentException e) {
+            throw new CommandException(e.getMessage());
         }
-
-        // Updating addressBook
-        model.setPerson(personToTag, newPerson);
-        model.getActiveTags().incrementTags(addedTags);
-        return new CommandResult(String.format(MESSAGE_TAG_PERSON_SUCCESS, personToTag.getName(), addedTagsString));
     }
 
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_TAG_LIST_SIZE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -55,13 +54,12 @@ public class AddCommandParser implements Parser<AddCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, e.getMessage()));
         }
 
-        if (tagSet.size() > 6) {
-            throw new ParseException(MESSAGE_INVALID_TAG_LIST_SIZE);
+        try {
+            Person person = new Person(name, phone, email, address, tagSet);
+            return new AddCommand(person);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(e.getMessage());
         }
-
-        Person person = new Person(name, phone, email, address, tagSet);
-
-        return new AddCommand(person);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_TAG_LIST_SIZE;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,6 +37,9 @@ public class Person {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        if (tags.size() > 6) {
+            throw new IllegalArgumentException(MESSAGE_INVALID_TAG_LIST_SIZE);
+        }
         this.tags.addAll(tags);
     }
 
@@ -49,6 +53,9 @@ public class Person {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        if (tags.size() > 6) {
+            throw new IllegalArgumentException(MESSAGE_INVALID_TAG_LIST_SIZE);
+        }
         this.tags.addAll(tags);
 
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -24,6 +24,7 @@ import seedu.address.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String TOO_MANY_TAGS = "Person has more than 6 tags!";
 
     private final String id;
     private final String name;
@@ -77,8 +78,12 @@ class JsonAdaptedPerson {
         final PersonId modelId = new PersonId(id);
 
         final List<Tag> personTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tags) {
-            personTags.add(tag.toModelType());
+        try {
+            for (JsonAdaptedTag tag : tags) {
+                personTags.add(tag.toModelType());
+            }
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
         }
 
         if (name == null) {
@@ -87,7 +92,14 @@ class JsonAdaptedPerson {
         if (!Name.isValidName(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
-        final Name modelName = new Name(name);
+
+        final Name modelName;
+        try {
+            modelName = new Name(name);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
+        }
+
 
         if (phone == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
@@ -95,7 +107,14 @@ class JsonAdaptedPerson {
         if (!Phone.isValidPhone(phone)) {
             throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
         }
-        final Phone modelPhone = new Phone(phone);
+
+        final Phone modelPhone;
+        try {
+            modelPhone = new Phone(phone);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
+        }
+
 
         if (email == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
@@ -103,7 +122,14 @@ class JsonAdaptedPerson {
         if (!Email.isValidEmail(email)) {
             throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
         }
-        final Email modelEmail = new Email(email);
+
+        final Email modelEmail;
+        try {
+            modelEmail = new Email(email);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
+        }
+
 
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
@@ -111,7 +137,14 @@ class JsonAdaptedPerson {
         if (!Address.isValidAddress(address)) {
             throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
         }
-        final Address modelAddress = new Address(address);
+
+        final Address modelAddress;
+        try {
+            modelAddress = new Address(address);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalValueException(e.getMessage());
+        }
+
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelId, modelName, modelPhone, modelEmail, modelAddress, modelTags);

--- a/src/test/java/seedu/address/logic/commands/TagCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/TagCommandTest.java
@@ -74,7 +74,7 @@ public class TagCommandTest {
 
         Set<Tag> tagSet = SampleDataUtil.getTagSet("tag1", "tag2", "tag3", "tag4", "tag5", "tag6");
         TagCommand command = new TagCommand(index, tagSet);
-        String expectedMessage = "Each person can only have up to 6 tags!";
+        String expectedMessage = "A contact can only have up to 6 tags";
         assertCommandFailure(command, model, expectedMessage);
     }
 


### PR DESCRIPTION
Resolve #304, resolve #292 

Previously, user could edit addressbook.json directly which bypasses certain restrictions placed on the data.

Resolved by implementing more stringent checks in the Jackson classes (JsonAdaptedXXX classes) by utilizing the class constructor which already checks for validity