### PR TITLE
Fix tag case insens

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -325,8 +325,10 @@ Examples:
 * `find Betsy` followed by `delete 1` deletes the 1st contact in the results of the `find` command.
 
 <box type="warning">
+
 If you want to remove a contact from a [wedding](#glossary), use the unassign command instead of the delete command.
 The delete command deletes the contact from the address book entirely.
+
 </box>
 <br><br/>
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -45,7 +45,7 @@ public class DeleteCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         Set<Tag> removedTags = personToDelete.getTags();
         model.deletePerson(personToDelete);
-        model.getActiveTags().decrementTag(removedTags);
+        model.getActiveTags().decrementTags(removedTags);
 
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }

--- a/src/main/java/seedu/address/logic/commands/UntagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntagCommand.java
@@ -72,7 +72,7 @@ public class UntagCommand extends Command {
                 this.removeTags(personToEdit.getTags(), tagsToRemoveFromPerson));
 
         model.setPerson(personToEdit, editedPerson);
-        model.getActiveTags().decrementTag(tagsToRemoveFromPerson);
+        model.getActiveTags().decrementTags(tagsToRemoveFromPerson);
 
         return new CommandResult(generateSuccessMessage(editedPerson, tagsToRemoveFromPerson));
     }

--- a/src/main/java/seedu/address/model/tag/ActiveTags.java
+++ b/src/main/java/seedu/address/model/tag/ActiveTags.java
@@ -52,7 +52,7 @@ public class ActiveTags {
      * Removes Tags from ActiveTags, and updates their respective occurrences
      * @param tagSet The Set of Tag to update
      */
-    public void decrementTag(Set<Tag> tagSet) {
+    public void decrementTags(Set<Tag> tagSet) {
         for (Tag t : tagSet) {
             Integer i = tagMap.get(t);
             if (i == 1) {
@@ -69,13 +69,13 @@ public class ActiveTags {
         String tagName = t.tagName;
         if (!tagColorMap.containsKey(tagName)) {
             String assigned = tagColors[tagColorMap.size() % tagColors.length]; // If more tags than colors, loops back
-            tagColorMap.put(tagName, assigned);
+            tagColorMap.put(tagName.toLowerCase(), assigned);
         }
     }
 
     private void unassignTagColor(Tag t) {
         String tagName = t.tagName;
-        tagColorMap.remove(tagName);
+        tagColorMap.remove(tagName.toLowerCase());
     }
 
     public HashMap<Tag, Integer> getMap() {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -71,6 +71,8 @@ public class PersonCard extends UiPart<Region> {
     private void setTagColor(Node tag) {
         Label label = (Label) tag;
         String tagName = label.getText();
-        tag.setStyle(String.format("-fx-text-fill: #383838; -fx-background-color: %s", tagColorMap.get(tagName)));
+        String colorCode = tagColorMap.get(tagName.toLowerCase());
+        String styleString = String.format("-fx-text-fill: #383838; -fx-background-color: %s", colorCode);
+        tag.setStyle(styleString);
     }
 }

--- a/src/test/java/seedu/address/model/tag/ActiveTagsTest.java
+++ b/src/test/java/seedu/address/model/tag/ActiveTagsTest.java
@@ -1,0 +1,4 @@
+package seedu.address.model.tag;
+
+public class ActiveTagTest {
+}

--- a/src/test/java/seedu/address/model/tag/ActiveTagsTest.java
+++ b/src/test/java/seedu/address/model/tag/ActiveTagsTest.java
@@ -1,4 +1,85 @@
 package seedu.address.model.tag;
 
-public class ActiveTagTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.TagColors;
+
+public class ActiveTagsTest {
+    private ActiveTags activeTags;
+
+    @BeforeEach
+    public void setUp() {
+        HashMap<Tag, Integer> occurrences = new HashMap<>();
+        occurrences.put(new Tag("tag1"), 5);
+        occurrences.put(new Tag("tag2"), 4);
+        occurrences.put(new Tag("tag3"), 3);
+
+        TagColors tagColors = new TagColors();
+        activeTags = new ActiveTags(occurrences, tagColors);
+    }
+
+    @Test
+    public void incrementTags_oneTag_correctOccurrence() {
+        Set<Tag> tagSet = new HashSet<>();
+        Tag tag = new Tag("tag1");
+        tagSet.add(tag);
+        activeTags.incrementTags(tagSet);
+        HashMap<Tag, Integer> map = activeTags.getMap();
+
+        assertEquals(map.get(tag), 6);
+    }
+
+    @Test
+    public void incrementTags_multipleTags_correctOccurrence() {
+        Set<Tag> tagSet = new HashSet<>();
+        Tag tag1 = new Tag("tag1");
+        Tag tag2 = new Tag("tag2");
+        Tag tag3 = new Tag("tag3");
+        tagSet.add(tag1);
+        tagSet.add(tag2);
+        tagSet.add(tag3);
+
+        activeTags.incrementTags(tagSet);
+        HashMap<Tag, Integer> map = activeTags.getMap();
+
+        assertEquals(map.get(tag1), 6);
+        assertEquals(map.get(tag2), 5);
+        assertEquals(map.get(tag3), 4);
+    }
+
+    @Test
+    public void decrementTags_oneTag_correctOccurence() {
+        Set<Tag> tagSet = new HashSet<>();
+        Tag tag = new Tag("tag1");
+        tagSet.add(tag);
+        activeTags.decrementTags(tagSet);
+        HashMap<Tag, Integer> map = activeTags.getMap();
+
+        assertEquals(map.get(tag), 4);
+    }
+
+    @Test
+    public void decrementTags_multipleTags_correctOccurrence() {
+        Set<Tag> tagSet = new HashSet<>();
+        Tag tag1 = new Tag("tag1");
+        Tag tag2 = new Tag("tag2");
+        Tag tag3 = new Tag("tag3");
+        tagSet.add(tag1);
+        tagSet.add(tag2);
+        tagSet.add(tag3);
+
+        activeTags.decrementTags(tagSet);
+        HashMap<Tag, Integer> map = activeTags.getMap();
+
+        assertEquals(map.get(tag1), 4);
+        assertEquals(map.get(tag2), 3);
+        assertEquals(map.get(tag3), 2);
+    }
 }

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -55,4 +55,11 @@ public class TagTest {
         assertNotEquals(tag, other);
     }
 
+    @Test
+    public void hashcode_sameCharsDiffCase_true() {
+        Tag tag = new Tag("test");
+        Tag other = new Tag("TEST");
+        assertEquals(tag.hashCode(), other.hashCode());
+    }
+
 }


### PR DESCRIPTION
Resolves #269

Added case insensitive checks for tag names in ActiveTags.tagColorMap to fix bug where same tags with different capitalization do not have colors rendered properly.